### PR TITLE
Errata to description of directory structure p.95.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ We also provide a PDF file that has color images of the screenshots/diagrams use
 * Page 46 (Paragraph 1, line 1): **Multiline comments get their name from their symbol – they start with an opening square bracket ([) ...** _should be_ **Multiline comments get their name from their symbol – they start with an # and an opening square bracket (#[) ...**
 
 * Page 75 (line 10): `main()` _should be_ `endmacro()`
+* Page 95 (Paragraph 3, line 2 and 3): **The `src` directory contains another `CMakeLists.txt` file along with the `.cpp` implementation files:** _should be_ **The `app1` directory contains another `CMakeLists.txt` file along with the `.cpp` implementation files:**
 * Page 107 (Paragraph 2, line 14 and 15): **Calling test_run() isn't very complicated at all. We start by setting the required standard, after which we call test_run() and print the collected information to the user:** _should be_ **Calling try_run() isn't very complicated at all. We start by setting the required
 standard, after which we call try_run() and print the collected information to the
 user:**


### PR DESCRIPTION
The original wording does not match to neither the figure 3.2, nor to the structure given in the example (see https://github.com/PacktPublishing/Modern-CMake-for-Cpp/tree/49208ac6e55139936f75233585a0c5c10b50a5d3/examples/chapter03/05-structure/src/app1).